### PR TITLE
Make item size properly ordered

### DIFF
--- a/src/pages/products/[productId]/index.tsx
+++ b/src/pages/products/[productId]/index.tsx
@@ -129,13 +129,13 @@ export default function Product() {
                     </SelectTrigger>
                     <SelectContent>
                       {product.availableSizes
-                        .map(prod => prod.productSize.size)
-                        .sort((a, b) => sortedSize.indexOf(a) - sortedSize.indexOf(b))
+                        .map((prod) => prod.productSize.size)
+                        .sort(
+                          (a, b) =>
+                            sortedSize.indexOf(a) - sortedSize.indexOf(b),
+                        )
                         .map((size) => (
-                          <SelectItem
-                            key={size}
-                            value={size}
-                          >
+                          <SelectItem key={size} value={size}>
                             {size}
                           </SelectItem>
                         ))}

--- a/src/pages/products/[productId]/index.tsx
+++ b/src/pages/products/[productId]/index.tsx
@@ -80,6 +80,8 @@ export default function Product() {
     });
   };
 
+  const sortedSize: Size[] = ["xxs", "xs", "s", "m", "l", "xl", "xxl"];
+
   return (
     <Layout>
       <Header />
@@ -126,14 +128,17 @@ export default function Product() {
                       <SelectValue placeholder="Size" />
                     </SelectTrigger>
                     <SelectContent>
-                      {product.availableSizes.map(({ productSize }) => (
-                        <SelectItem
-                          key={productSize.size}
-                          value={productSize.size}
-                        >
-                          {productSize.size}
-                        </SelectItem>
-                      ))}
+                      {product.availableSizes
+                        .map(prod => prod.productSize.size)
+                        .sort((a, b) => sortedSize.indexOf(a) - sortedSize.indexOf(b))
+                        .map((size) => (
+                          <SelectItem
+                            key={size}
+                            value={size}
+                          >
+                            {size}
+                          </SelectItem>
+                        ))}
                     </SelectContent>
                   </Select>
                 </div>


### PR DESCRIPTION
Change:
- Sort the item size first before ordering

<img width="331" alt="image" src="https://github.com/ssss-sfu/merch-store/assets/70176191/9a6fcdb4-ceaa-48b7-9667-dcbe7562b654">
